### PR TITLE
Dynamic creation of finger_table

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -48,12 +48,3 @@ pub fn is_in_range(key: &BigInt, left: &BigInt, right: &BigInt) -> bool {
         (key > right && key < left) || (left == right && key != left)
     }
 }
-
-pub fn get_fix_finger_id(key: &BigInt, exponent: usize) -> BigInt {
-    // Get the offset
-    let two: BigInt = 2.to_bigint().unwrap();
-    let offset: BigInt = pow(two.clone(), exponent);
-
-    // Sum
-    key + offset
-}


### PR DESCRIPTION
#24
- Improve print finger_table
- Rename `get_fix_finger_id()` to `get_finger_id()`. Move to `finger.rs`
- Change `finger_table.put()`: can now also push values
- Initialize with successor, then we add entries depending on next in
  `node.fix_fingers()` (maximum is `chord::FINGERTABLE_SIZE` which depends on the maximum bit_size of the used hashing)